### PR TITLE
fix: Incorrect description metadata tag

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,8 +32,8 @@ export default function Home() {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      title={`${siteConfig.title}`}
+      description="envd: Development Environment for Data Scientists">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
This should fix the social preview card when sharing the link in the chat.
<img width="690" alt="Screen Shot 2022-06-11 at 2 34 44 PM" src="https://user-images.githubusercontent.com/4269898/173200688-b622c23b-9b73-4855-8270-528b35c9e6df.png">

