### PR TITLE
fix: Reorder the tab in getting started

### DIFF
--- a/docs-zh/guide/getting-started.md
+++ b/docs-zh/guide/getting-started.md
@@ -79,37 +79,6 @@ def tensorboard(envd_port=6006, envd_dir="/home/envd/logs",
   <img src="https://user-images.githubusercontent.com/5100735/189928628-543f4851-87b7-462b-b811-372cbf46ff25.svg" width="65%"/>
 </p>
 
-🐍 **单个配置文件完成一切需求**
-
-开发环境中充满了 Dockerfile、bash 脚本、Kubernetes YAML 文件和许多其他冗长的脚本文件，这些文件在环境的不断迭代下可能失效。有了 envd 之后，你只需要一个配置文件`build.envd`[^1]，它对本地 Docker 和云端的 Kubernetes 集群都适用。
-
-![envd](https://user-images.githubusercontent.com/5100735/188821980-dcbd9069-b504-436a-9ffd-05ac5543a6d1.png)
-
-[^1]: 构建语言实际上是 Python 的一个方言 [starlark](https://docs.bazel.build/versions/main/skylark/language.html).
-
-✍️ **不必为了工程化牺牲开发者体验**
-
-envd 环境主要通过 SSH 接口访问。你可以在环境中使用 VSCode-Remote、Jupyter、Pycharm 或其他你任何喜欢的 IDE。除此之外，你可以在 envd 文件里声明你想要的 IDE 插件， `envd` 会安装他们。
-
-```python
-def build():
-    install.vscode_extensions([
-        "ms-python.python",
-    ])
-```
-
-☁️ **可追踪的开发环境**。
-
-你是否正在进行多个项目，而这些项目都需要不同版本的 CUDA？ `envd` 可以帮助你创建隔离的、干净的环境。
-
-## 谁应该使用 envd？
-
-我们专注于帮助开发 AI/ML 模型的数据科学家和团队。在日常的开发过程中，他们可能遇到以下问题
-
-- 用 Python/R/Julia、CUDA、Docker、SSH 等构建开发环境。你是否有一个复杂的 Docker 文件或构建脚本，构建了所有的开发环境，但总是需要不断修改？
-- 环境更新。你是否总是需要问基础设施工程师如何在 Dockerfile 中添加一个新的 Python/R/Julia 包？
-- 管理环境和机器。你是否总是忘记哪些机器是用于特定项目的，因为你同时处理多个项目？
-
 ## 三分钟建立你的 envd 环境
 
 ### 安装要求
@@ -119,12 +88,12 @@ def build():
 ### 安装和初始化 `envd`
 
 <tabs>
-<tab name="安装脚本">
+<tab name="pip">
 
-在终端中运行以下命令即可安装最新版本的 `envd`:
+`envd` 也可以用 `pip` 来安装。
 
 ```bash
-curl -sSfL https://envd.tensorchord.ai/install.sh | sudo sh
+pip3 install --upgrade envd
 ```
 
 </tab>
@@ -145,12 +114,12 @@ pipx install envd
 ```
 
 </tab>
-<tab name="pip">
+<tab name="安装脚本">
 
-`envd` 也可以用 `pip` 来安装（只支持 Python3）。
+在终端中运行以下命令即可安装最新版本的 `envd`:
 
 ```bash
-pip3 install --upgrade envd
+curl -sSfL https://envd.tensorchord.ai/install.sh | sudo sh
 ```
 
 </tab>

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -78,38 +78,6 @@ For example, the PyPI cache is shared across builds and thus the package will be
   <img src="https://user-images.githubusercontent.com/5100735/189928628-543f4851-87b7-462b-b811-372cbf46ff25.svg" width="65%"/>
 </p>
 
-🐍 **One configuration to rule them all**
-
-Development environments are full of Dockerfiles, bash scripts, Kubernetes YAML manifests, and many other clunky files that are always breaking. You just need one configuration file `build.envd`[^1], it works both for local Docker and Kubernetes clusters in the cloud.
-
-![envd](https://user-images.githubusercontent.com/5100735/188821980-dcbd9069-b504-436a-9ffd-05ac5543a6d1.png)
-
-[^1]: The build language is [starlark](https://docs.bazel.build/versions/main/skylark/language.html), which is a dialect of Python.
-
-✍️ **Don't sacrifice your developer experience**
-
-SSH is configured for the created environment. You can use vscode-remote, jupyter, pycharm or other IDEs that you love. Besides this, declare the IDE extensions you want, let `envd` take care of them.
-
-```python
-def build():
-    install.vscode_extensions([
-        "ms-python.python",
-    ])
-```
-
-☁️ **No polluted environment**
-
-Are you working on multiple projects, all of which need different versions of CUDA? `envd` helps you create isolated and clean environments.
-
-## Who should use envd?
-
-We’re focused on helping data scientists and teams that develop AI/ML models. And they may suffer from:
-
-- building the development environments with Python/R/Julia, CUDA, Docker, SSH, and so on. Do you have a complicated Dockerfile or build script that sets up all your dev environments, but is always breaking?
-- Updating the environment. Do you always need to ask infrastructure engineers how to add a new Python/R/Julia package in the Dockerfile?
-- Managing environments and machines. Do you always forget which machines are used for the specific project, because you handle multiple projects concurrently?
-
-
 ## Setup your first `envd` environment in 3 minutes
 ### Requirements
 
@@ -118,12 +86,12 @@ We’re focused on helping data scientists and teams that develop AI/ML models. 
 ### Install and bootstrap `envd`
 
 <tabs>
-<tab name="Install Script">
+<tab name="pip">
 
-Run the following command in your terminal to install the latest release of `envd`:
+`envd` can be installed with `pip`.
 
 ```bash
-curl -sSfL https://envd.tensorchord.ai/install.sh | sudo sh
+pip3 install --upgrade envd
 ```
 
 </tab>
@@ -144,12 +112,12 @@ pipx install envd
 ```
 
 </tab>
-<tab name="pip">
+<tab name="Install Script">
 
-`envd` can be installed with `pip` (only support Python3).
+Run the following command in your terminal to install the latest release of `envd`:
 
 ```bash
-pip3 install --upgrade envd
+curl -sSfL https://envd.tensorchord.ai/install.sh | sudo sh
 ```
 
 </tab>


### PR DESCRIPTION
Keep pip in the first tab, then homebrew, pipx, and installation script.

Signed-off-by: Ce Gao <cegao@tensorchord.ai>