### PR TITLE
docs: update `envd destroy` commands to reflect envd/#1568

### DIFF
--- a/docs-zh/guide/build-envd.md
+++ b/docs-zh/guide/build-envd.md
@@ -89,12 +89,12 @@ $ ssh demo.envd
 envd@588f26349c61 $ # 欢迎回来！
 ```
 
-4. 删除环境，如果您不再使用它，请不要忘记使用 `envd destroy` 命令来删除环境。
+4. 删除环境，如果您不再使用它，请不要忘记使用 `envd destroy` 命令来删除环境。使用 `-p` 参数指定要删除的环境的路径。
 
 <custom-title title="删除环境">
 
 ```bash
-$ envd destroy
+$ envd destroy -p .
 INFO[2022-06-10T19:09:49+08:00] <project-directory-name> is destroyed
 ```
 

--- a/docs/guide/build-envd.md
+++ b/docs/guide/build-envd.md
@@ -91,12 +91,12 @@ envd@588f26349c61 $ # You are in the environment again!
 
 </custom-title>
 
-Do not forget to remove the environment if you do not use it.
+Do not forget to remove the environment if you do not use it. Use the `-p` flag to specify the path of the environment to destroy.
 
 <custom-title title="destroy the environment">
 
 ```text 
-$ envd destroy
+$ envd destroy -p .
 INFO[2022-06-10T19:09:49+08:00] <project-directory-name> is destroyed
 ```
 


### PR DESCRIPTION
## Summary
The previous behavior of `envd destroy` without both `--path` and `--name` flags was to attempt to delete the environment in the current working directory. [PR envd/#1568](https://github.com/tensorchord/envd/pull/1568) prevents this behavior by causing `envd destroy` to fail if both flags are not provided. This PR updates `envd destroy` examples in `zh` and `en` documentations to reflect this change.

### Previous Behavior
```bash
$ envd destroy
INFO[2023-04-22T06:49:10Z] image(sha256:1a891bf790ef45aec292f63a414fcc4338e1b9e911a313570fb592f9e316a50f) is destroyed 
INFO[2023-04-22T06:49:10Z] environment(envd-quick-start) is destroyed  
```

### Current Behavior
```bash
$ envd destroy
error: You must specify either the --path or --name flag. If you want to destroy the current environment, please run `envd destroy --path .`
```